### PR TITLE
Feature/mbus 365 alert banner refinements

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,17 @@ The above should display the alert banner as the very top of your site. (As long
 
 ## Styling Alert Banner
 
-In your Alert Banner element, click on the style tab and choose the background color, font color and Icon that the banner should use.
+You can define your own styles in yml.
+
+```yml
+DNADesign\AlertBanner\AlertBanner:
+  Themes:
+    Default:
+      Title: 'Default Theme'
+      FontColor: '#000000'
+      BGColor: '#FFFFFF'
+      Icon: 'cross-red'
+```
 
 ## CMS
 

--- a/_config/config.yml
+++ b/_config/config.yml
@@ -9,3 +9,11 @@ PageController:
 SilverStripe\Control\Director:
   rules:
     'alerts': 'DNADesign\AlertBanner\AlertBannerController'
+
+# DNADesign\AlertBanner\AlertBanner:
+  # Themes:
+  #   Default:
+  #     Title: 'Default Theme'
+  #     FontColor: '#000000'
+  #     BGColor: '#FFFFFF'
+  #     Icon: 'cross-red'

--- a/client/src/images/svg/exclamation-mark.svg
+++ b/client/src/images/svg/exclamation-mark.svg
@@ -1,4 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 92 92">
+<?xml version="1.0" encoding="utf-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 92 92" width="92" height="92">
   <title>BUG_Update_Icon-2</title>
   <g>
     <path d="M46,3A43,43,0,1,0,89,46,43,43,0,0,0,46,3m0,89A46,46,0,1,1,92,46,46.05,46.05,0,0,1,46,92" style="fill: #d0275a"/>

--- a/src/extensions/ControllerExtension.php
+++ b/src/extensions/ControllerExtension.php
@@ -5,6 +5,7 @@ namespace DNADesign\AlertBanner;
 use SilverStripe\Assets\File;
 use SilverStripe\View\Requirements;
 use SilverStripe\Core\Extension;
+use Silverstripe\Control\NullHTTPRequest;
 
 /**
  * This extension adds the ability to control the max-age per originator.
@@ -33,7 +34,13 @@ class ControllerExtension extends Extension
 
     public function alertCanShow($alert)
     {
-        $session = $this->owner->getRequest()->getSession();
+        $request = $this->owner->getRequest();
+
+        if ($request instanceof NullHTTPRequest) {
+            return false;
+        }
+
+        $session = $request->getSession();
         $alerts = $session->get('AlertBanners');
         $show = true;
 


### PR DESCRIPTION
- For the exclusion/ inclusion rules:
Add a many-many alertexclusionrule object to each alert, managed in a gridfield. Each item can be either exclude or include.
On any page, if it is in the exclusion list, or any of its parents are in the excluded list excluded unless an inclusion rule is found first then the alert in excluded.
This allows us to exclude then include in the nesting. Note this will be experimental, it may be easier just to have a blank exclusion list fo a page and its children.
- Ensure thew RichLinks extension is used on content. This ensures the external link icon
- Add Versioned extension on enable publishing/draft. There wont be a history viewer though.
- Summary fields should be: id, title, Created, Display From-Until, Type (theme)
- Icons should be defined within the type theme, not via the CMS